### PR TITLE
Make lambdex also work with python3.6

### DIFF
--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -32,7 +32,7 @@ class LambdexInfo(object):
 
 def _write_zip_content(zf, filename, content):
   info = zipfile.ZipInfo(filename)
-  info.external_attr = 0755 << 16L
+  info.external_attr = 0o755 << 16
   zf.writestr(info, content)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ skip_missing_interpreters = True
 minversion = 1.8
 envlist =
 	py27
+	py36
 
 [base]
 deps =


### PR DESCRIPTION
AWS has added support for python3.6
which no longer accepts octal values as just leading with a zero.
This change is backward compatible with python2.7.