### PR TITLE
Support pex 1.6.0+.

### DIFF
--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -58,7 +58,6 @@ def write_lambdex_handler(pex_zip, options):
 
   with contextlib.closing(zipfile.ZipFile(pex_zip, 'a')) as zf:
     if script is not None:
-      pathname = os.path.realpath(options.script)
       with open(os.path.realpath(options.script), 'rb') as fp:
         _write_zip_content(zf, script, fp.read())
     _write_zip_content(zf, 'LAMBDEX-INFO', lambdex_info.to_json())

--- a/lambdex/resources/lambdex_handler.py
+++ b/lambdex/resources/lambdex_handler.py
@@ -18,7 +18,15 @@ if __entry_point__ is None:
 sys.path[0] = os.path.abspath(sys.path[0])
 sys.path.insert(0, os.path.abspath(os.path.join(__entry_point__, '.bootstrap')))
 
-from _pex.pex_bootstrapper import bootstrap_pex_env, is_compressed
+try:
+  # PEX >= 1.6.0
+  from pex.third_party.pkg_resources import EntryPoint as __EntryPoint
+  from pex.pex_bootstrapper import bootstrap_pex_env, is_compressed
+except ImportError:
+  # PEX < 1.6.0 has an install requirement of setuptools which we leverage knowledge of.
+  from pkg_resources import EntryPoint as __EntryPoint
+  from _pex.pex_bootstrapper import bootstrap_pex_env, is_compressed
+
 bootstrap_pex_env(__entry_point__)
 
 if is_compressed(__entry_point__):
@@ -31,7 +39,6 @@ else:
 
 import json as __json
 __lambdex_info = __json.loads(__lambdex_info_blob)
-from pkg_resources import EntryPoint as __EntryPoint
 __RUNNER = __EntryPoint.parse('run = %s' % __lambdex_info['entry_point']).resolve()
 
 def handler(event, context):

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,39 @@ skip_missing_interpreters = True
 minversion = 1.8
 envlist =
 	py27
-	py36
+	py37
 
-[base]
+[integration]
 deps =
-	pex>=1.1.15
+  tox
+commands =
+  pex -r {toxinidir}/examples/requirements.txt -o {toxinidir}/dist/lambda_function.pex
+  tox -e pex
+  {toxinidir}/dist/lambdex build -s examples/example_function.py -H handler {toxinidir}/dist/lambda_function.pex
+  {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/wickman/lambdex"\}, None)'
+
+[testenv:int-pre-pex1.6]
+# NB: 1.4.8 is the first pre-1.6.0 version to cupport -c.
+deps =
+  {[integration]deps}
+  pex==1.4.8
+commands = {[integration]commands}
+
+[testenv:int-post-pex1.6]
+deps =
+  {[integration]deps}
+  pex>=1.6.0
+commands = {[integration]commands}
 
 [testenv:pex]
 deps = pex==1.1.15
-commands = pex . -e lambdex.bin.lambdex:main -o dist/lambdex
+commands = pex . -e lambdex.bin.lambdex:main -o {toxinidir}/dist/lambdex
 
 [testenv:wheel]
 deps = wheel
-commands = python setup.py bdist_wheel --dist-dir dist
+commands = python setup.py bdist_wheel --dist-dir {toxinidir}/dist
 
 [testenv:lambdex]
-deps =
-	{[base]deps}
 commands = lambdex {posargs}
 
 [testenv:style]


### PR DESCRIPTION
In pex 1.6.0+ setuptools (pkg_resources) is now vendored and shaded
and, as a result, not available via a leak from the pex bootstrap
environment. Double down on our pex api dependence and test for newer
pex by using its pex.third_party importer to grab a hold of
pkg_resources.

Fixes #3