### PR TITLE
Upgrade tox to fix CI.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = True
-minversion = 1.8
+minversion = 3.23.0
 envlist =
   style
   py38-int-pre-pex1.6


### PR DESCRIPTION
The old minversion did not support the explicit true/false setting for
--skip-missing-interpreters used by the run-tox action.