### PR TITLE
Improve CLI ergonomics.

### DIFF
--- a/lambdex/__main__.py
+++ b/lambdex/__main__.py
@@ -1,0 +1,9 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from lambdex.bin import lambdex
+
+if __name__ == "__main__":
+    lambdex.main()

--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -14,6 +14,8 @@ import zipfile
 
 from pex.pex_bootstrapper import bootstrap_pex_env
 
+from lambdex.version import __version__
+
 try:
     # PEX >= 1.6.0
     from pex.third_party.pkg_resources import EntryPoint
@@ -85,7 +87,11 @@ def build_lambdex(args):
 
 
 def configure_build_command(parser):
-    parser = parser.add_parser("build", help="build a lambdex package")
+    parser = parser.add_parser(
+        "build",
+        help="build a lambdex package",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.set_defaults(func=build_lambdex)
 
     parser.add_argument(
@@ -116,7 +122,7 @@ def configure_build_command(parser):
         dest="handler",
         default="handler",
         metavar="FUNCTION",
-        help='Invoke this function within the script.  Default: "handler"',
+        help="Invoke this function within the script.",
     )
 
 
@@ -191,7 +197,11 @@ def test_lambdex(args):
 
 
 def configure_test_command(parser):
-    parser = parser.add_parser("test", help="test a lambdex package")
+    parser = parser.add_parser(
+        "test",
+        help="test a lambdex package",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.set_defaults(func=test_lambdex)
 
     parser.add_argument(
@@ -223,7 +233,14 @@ def configure_test_command(parser):
 
 
 def configure_clp():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-V", "--version", action="version", version=__version__)
+
+    def usage(_):
+        parser.print_help()
+
+    parser.set_defaults(func=usage)
+
     subparsers = parser.add_subparsers()
     configure_build_command(subparsers)
     configure_test_command(subparsers)

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands = {[_integration]commands}
 
 [testenv:pex]
 deps = pex==2.1.41
-commands = pex . -e lambdex.bin.lambdex:main -o {toxinidir}/dist/lambdex
+commands = pex . -c lambdex -o {toxinidir}/dist/lambdex
 
 [testenv:lambdex]
 commands = lambdex {posargs}


### PR DESCRIPTION
+ Add `-V` / `--version` support.
+ Use a help formatter that prints default values.
+ Add support for `python -mlambdex`.
+ Fix lambdex when called with no arguments to print help.