### PR TITLE
allow ability to pass other args to lambdex_handler.handler

### DIFF
--- a/lambdex/resources/lambdex_handler.py
+++ b/lambdex/resources/lambdex_handler.py
@@ -50,5 +50,5 @@ __lambdex_info = __json.loads(__lambdex_info_blob)
 __RUNNER = __EntryPoint.parse("run = %s" % __lambdex_info["entry_point"]).resolve()
 
 
-def handler(event, context):
-    return __RUNNER(event, context)
+def handler(event, context, *args, **kwargs):
+    return __RUNNER(event, context, *args, **kwargs)


### PR DESCRIPTION
Currently using lambdex to package artifacts for Serverless framework. [docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html) tell me I need to be able to referene a callback as a third parameter but since lambdex_handler always just has event and context this blocks me from be able to try out the authorizer callback. Is there any issue with being able to pass other arguments to lambdex_handler.handler?