### PR TITLE
Use LAMBDEX_ENTRY_POINT env var for entry point if available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.1.5
+
+This release adds support for customizing the entry point at runtime using `LAMBDEX_ENTRY_POINT`
+
 ## 0.1.4
 
 This release fixes the implicit Lambdex dependency on setuptools and uses the vendored version

--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ on AWS Lambda.  See [documentation](http://docs.aws.amazon.com/AmazonECR/latest/
 for information about that image.
 
 The minimum Dockerfile to produce can environment that can build Amazon Linux-specific pex files can be found [here](https://github.com/pantsbuild/lambdex/blob/main/Dockerfile)
+
+### controlling runtime execution
+
+To override the entry point that was specified at build time, you can use the `LAMBDEX_ENTRY_POINT` env var:
+
+    LAMBDEX_ENTRY_POINT=mymodule.myapp:other_handler ...

--- a/examples/example_function.py
+++ b/examples/example_function.py
@@ -6,3 +6,7 @@ import requests
 def handler(event, context):
     url = event["url"]
     print("%s sha256:%s" % (url, hashlib.sha256(requests.get(url).content).hexdigest()))
+
+
+def other_handler(event, context):
+    print("Other handler invoked")

--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -180,15 +180,18 @@ def test_lambdex(args):
     bootstrap_pex_env(args.pex)
 
     with cached_environment(args.root, args.pex) as target:
-        with open(os.path.join(target, "LAMBDEX-INFO"), "rb") as fp:
-            lambdex_info_blob = fp.read()
+        lambdex_entry_point = os.environ.get("LAMBDEX_ENTRY_POINT")
+        if not lambdex_entry_point:
+            with open(os.path.join(target, "LAMBDEX-INFO"), "rb") as fp:
+                lambdex_info_blob = fp.read()
 
-        lambdex_info = LambdexInfo.from_string(lambdex_info_blob)
+            lambdex_info = LambdexInfo.from_string(lambdex_info_blob)
+            lambdex_entry_point = lambdex_info.entry_point
 
         sys.path.append(target)
 
         with chdir(target):
-            runner = EntryPoint.parse("run = %s" % lambdex_info.entry_point).resolve()
+            runner = EntryPoint.parse("run = %s" % lambdex_entry_point).resolve()
             if args.empty:
                 runner({}, None)
             else:

--- a/lambdex/resources/lambdex_handler.py
+++ b/lambdex/resources/lambdex_handler.py
@@ -33,21 +33,25 @@ except ImportError:
 
 bootstrap_pex_env(__entry_point__)
 
-import zipfile
+__lambdex_entry_point = os.environ.get("LAMBDEX_ENTRY_POINT")
 
-if zipfile.is_zipfile(__entry_point__):
-    import contextlib
+if not __lambdex_entry_point:
+    import json as __json
+    import zipfile
 
-    with contextlib.closing(zipfile.ZipFile(__entry_point__)) as zf:
-        __lambdex_info_blob = zf.read("LAMBDEX-INFO")
-else:
-    with open(os.path.join(__entry_point__, "LAMBDEX-INFO"), "rb") as fp:
-        __lambdex_info_blob = fp.read()
+    if zipfile.is_zipfile(__entry_point__):
+        import contextlib
 
-import json as __json
+        with contextlib.closing(zipfile.ZipFile(__entry_point__)) as zf:
+            __lambdex_info_blob = zf.read("LAMBDEX-INFO")
+    else:
+        with open(os.path.join(__entry_point__, "LAMBDEX-INFO"), "rb") as fp:
+            __lambdex_info_blob = fp.read()
 
-__lambdex_info = __json.loads(__lambdex_info_blob)
-__RUNNER = __EntryPoint.parse("run = %s" % __lambdex_info["entry_point"]).resolve()
+    __lambdex_info = __json.loads(__lambdex_info_blob)
+    __lambdex_entry_point = __lambdex_info["entry_point"]
+
+__RUNNER = __EntryPoint.parse("run = %s" % __lambdex_entry_point).resolve()
 
 
 def handler(event, context):

--- a/lambdex/version.py
+++ b/lambdex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = True
 skip_missing_interpreters = True
 minversion = 3.23.0
 envlist =
-  style
+  fmt-check
   py39-int-pre-pex1.6
   py39-int-post-pex1.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,10 @@ commands =
   tox -e pex
   {toxinidir}/dist/lambdex build -s examples/example_function.py -H handler {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
+  tox -e entry-point-env-var
 
 [testenv:py{27,36,37,38,39}-int-pre-pex1.6]
-# NB: 1.4.8 is the first pre-1.6.0 version to cupport -c.
+# NB: 1.4.8 is the first pre-1.6.0 version to support -c.
 deps =
   {[_integration]deps}
   pex==1.4.8
@@ -36,8 +37,14 @@ deps =
   pex>=1.6.0
 commands = {[_integration]commands}
 
+[testenv:entry-point-env-var]
+setenv =
+  LAMBDEX_ENTRY_POINT = example_function:other_handler
+commands =
+  {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{\}, None)'
+
 [testenv:pex]
-deps = pex==2.1.41
+deps = pex==2.1.43
 commands = pex . -c lambdex -o {toxinidir}/dist/lambdex
 
 [testenv:lambdex]

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = {[_integration]commands}
 setenv =
   LAMBDEX_ENTRY_POINT = example_function:other_handler
 commands =
-  {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{\}, None)'
+  {toxinidir}/dist/lambdex test --empty {toxinidir}/dist/lambda_function.pex
 
 [testenv:pex]
 deps = pex==2.1.43


### PR DESCRIPTION
We have a use case where we'd like to use a _single_ PEX file to support multiple Lambdas. Rather than building multiple PEX files with different `LAMBDEX-INFO` files, we'd prefer to specify the entry point at runtime via an environment variable. PEX supports something similar with the [`PEX_MODULE`](https://pex.readthedocs.io/en/v2.1.42/api/vars.html#PEX_MODULE) and [`PEX_SCRIPT`](https://pex.readthedocs.io/en/v2.1.42/api/vars.html#PEX_MODULE) env vars.

This PR updates `lambdex_handler.py` to use the `LAMBDEX_ENTRY_POINT` environment variable (when present) as the entry point instead of the entry point specified in `LAMBDEX-INFO`.