### PR TITLE
Create arg that can specify module name.

### DIFF
--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -74,12 +74,13 @@ def write_lambdex_handler(pex_zip, options):
                 _write_zip_content(zf, script, fp.read())
         _write_zip_content(zf, "LAMBDEX-INFO", lambdex_info.to_json())
         _write_zip_content(
-            zf, "lambdex_handler.py", pkgutil.get_data("lambdex.resources", "lambdex_handler.py")
+            zf, options.module, pkgutil.get_data("lambdex.resources", "lambdex_handler.py")
         )
 
 
 # lambdex build foo.pex
 #   [-H handler]
+#   [-M module.py]
 #   [-s script.py]
 #   [-e pkg:symbol]
 def build_lambdex(args):
@@ -123,6 +124,15 @@ def configure_build_command(parser):
         default="handler",
         metavar="FUNCTION",
         help="Invoke this function within the script.",
+    )
+
+    parser.add_argument(
+        "-M",
+        "--script-module",
+        dest="module",
+        default="lambdex_handler.py",
+        metavar="FILENAME",
+        help="Root module of the lambda.",
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 commands =
   pex -r {toxinidir}/examples/requirements.txt -o {toxinidir}/dist/lambda_function.pex
   tox -e pex
-  {toxinidir}/dist/lambdex build -s examples/example_function.py -H handler {toxinidir}/dist/lambda_function.pex
+  {toxinidir}/dist/lambdex build -s examples/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
   tox -e entry-point-env-var
 


### PR DESCRIPTION
This allows the invoker to specify what the root module should be that will be invoked. In the case of GCP Cloud Functions, the deployment assumes that the handler lives in a module `main.py`.

So to test this I did something like:
`pex -r examples/requirements.txt -o dist/gcp_function.zip `
then
`lambdex build -s examples/example_function.py -H handler -M main.py dist/gcp_function.zip`

I deployed it to GCP and it was able to run successfully. 