### PR TITLE
Migrate from `::set-output` to `$GITHUB_OUTPUT`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
             tox-env: package
     steps:
       - name: Checkout Lambdex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
       - name: Check ${{ matrix.check-name }}
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: ${{ matrix.tox-env }}
   integration-tests:
@@ -40,12 +40,12 @@ jobs:
             python-version: [3, 8]
     steps:
       - name: Checkout Lambdex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ join(matrix.python-version, '') }}-int-pre-pex1.6,py${{ join(matrix.python-version, '') }}-int-post-pex1.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
             RELEASE_TAG=${GITHUB_REF#refs/tags/}
           fi
           if [[ "${RELEASE_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "::set-output name=release-tag::${RELEASE_TAG}"
-            echo "::set-output name=release-version::${RELEASE_TAG#v}"
+            echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+            echo "release-version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
           else
             echo "::error::Release tag '${RELEASE_TAG}' must match 'v\d+.\d+.\d+'."
             exit 1
@@ -38,15 +38,15 @@ jobs:
     needs: determine-tag
     steps:
       - name: Checkout ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Publish ${{ needs.determine-tag.outputs.release-tag }}
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         env:
           FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
           FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/examples/event_based/requirements.txt
+++ b/examples/event_based/requirements.txt
@@ -1,1 +1,4 @@
-requests
+requests<=2.27.1
+
+# Pin low to work around Python 3 syntax creeping in.
+certifi<=2021.10.8

--- a/examples/gcp_http/requirements.txt
+++ b/examples/gcp_http/requirements.txt
@@ -1,2 +1,8 @@
-flask<2
-requests
+flask==1.1.4
+requests<=2.27.1
+
+# Pin low to work around Python 3 syntax creeping in.
+certifi<=2021.10.8
+
+# Work around 'cannot import name 'soft_unicode' from 'markupsafe' by pinning it low.
+MarkupSafe<=2.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ requires-python = ">=2.7,<3.10,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [tool.flit.metadata.requires-extra]
 test-gcp-http = [
-  "flask<2; python_version < '3.6'",
-  "flask~=2.0.0; python_version >= '3.6'"
+  "flask==1.1.4; python_version < '3.6'",
+  "flask==2.0.3; python_version >= '3.6' and python_version < '3.7'",
+  "flask==2.2.2; python_version >= '3.7'",
 ]
 
 [tool.flit.scripts]

--- a/scripts/build-lambdex-pex.py
+++ b/scripts/build-lambdex-pex.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+from argparse import ArgumentParser
+
+
+def main(dest):
+    # N.B.: Pex outputs --version to STDERR under Python 2.7 argparse; so we capture both streams.
+    output = subprocess.check_output(args=["pex", "--version"], stderr=subprocess.STDOUT)
+
+    # iN.B.: Older versions of Pex respond to --version with 'pex <version>' whereas newer versions
+    # of Pex just respond with '<version>'.
+    pex_version = output.decode("utf-8").strip().split(" ", 1)[-1]
+
+    pex_requirement = "pex=={version}".format(version=pex_version)
+    print(
+        "Using {pex_requirement} to build a Lambdex PEX.".format(pex_requirement=pex_requirement),
+        file=sys.stderr,
+    )
+    subprocess.check_call(
+        args=["pex", "--python", sys.executable, ".", pex_requirement, "-c", "lambdex", "-o", dest]
+    )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("dest", nargs=1)
+    options = parser.parse_args()
+    main(options.dest[0])

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,8 @@ basepython = python3
 skip_install = true
 deps =
   black==21.4b1
+  # The 8.1.0 release of click breaks black; so we pin.
+  click==8.0.1
   isort==5.8.0
 commands =
   black .

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
   {[_integration]deps}
 commands =
   {[_integration]commands}
+  pex --version
   pex -r {toxinidir}/examples/event_based/requirements.txt -o {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambdex build -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
@@ -36,6 +37,7 @@ deps =
   .[test-gcp-http]
 commands =
   {[_integration]commands}
+  pex --version
   pex -r {toxinidir}/examples/gcp_http/requirements.txt -o {toxinidir}/dist/gcp_http_function.pex
   {toxinidir}/dist/lambdex build -s examples/gcp_http/example_http_function.py -H handler -M main.py {toxinidir}/dist/gcp_http_function.pex
   {toxinidir}/dist/lambdex test --type gcp-http --empty {toxinidir}/dist/gcp_http_function.pex
@@ -65,7 +67,8 @@ commands =
 
 [testenv:pex]
 deps = pex==2.1.43
-commands = pex . -c lambdex -o {toxinidir}/dist/lambdex
+commands =
+  python scripts/build-lambdex-pex.py {toxinidir}/dist/lambdex
 
 [testenv:lambdex]
 commands = lambdex {posargs}


### PR DESCRIPTION
This gets ahead of the deprecation announced here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/