### PR TITLE
Fix main CI

### DIFF
--- a/examples/event_based/requirements.txt
+++ b/examples/event_based/requirements.txt
@@ -1,1 +1,4 @@
-requests
+requests<=2.27.1
+
+# Pin low to work around Python 3 syntax creeping in.
+certifi<=2021.10.8

--- a/examples/gcp_http/requirements.txt
+++ b/examples/gcp_http/requirements.txt
@@ -1,2 +1,8 @@
-flask<2
-requests
+flask==1.1.4
+requests<=2.27.1
+
+# Pin low to work around Python 3 syntax creeping in.
+certifi<=2021.10.8
+
+# Work around 'cannot import name 'soft_unicode' from 'markupsafe' by pinning it low.
+MarkupSafe<=2.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ requires-python = ">=2.7,<3.10,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [tool.flit.metadata.requires-extra]
 test-gcp-http = [
-  "flask<2; python_version < '3.6'",
-  "flask~=2.0.0; python_version >= '3.6'"
+  "flask==1.1.4; python_version < '3.6'",
+  "flask==2.0.3; python_version >= '3.6' and python_version < '3.7'",
+  "flask==2.2.2; python_version >= '3.7'",
 ]
 
 [tool.flit.scripts]

--- a/scripts/build-lambdex-pex.py
+++ b/scripts/build-lambdex-pex.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+from argparse import ArgumentParser
+
+
+def main(dest):
+    # N.B.: Pex outputs --version to STDERR under Python 2.7 argparse; so we capture both streams.
+    output = subprocess.check_output(args=["pex", "--version"], stderr=subprocess.STDOUT)
+
+    # iN.B.: Older versions of Pex respond to --version with 'pex <version>' whereas newer versions
+    # of Pex just respond with '<version>'.
+    pex_version = output.decode("utf-8").strip().split(" ", 1)[-1]
+
+    pex_requirement = "pex=={version}".format(version=pex_version)
+    print(
+        "Using {pex_requirement} to build a Lambdex PEX.".format(pex_requirement=pex_requirement),
+        file=sys.stderr,
+    )
+    subprocess.check_call(
+        args=["pex", "--python", sys.executable, ".", pex_requirement, "-c", "lambdex", "-o", dest]
+    )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("dest", nargs=1)
+    options = parser.parse_args()
+    main(options.dest[0])

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,8 @@ basepython = python3
 skip_install = true
 deps =
   black==21.4b1
+  # The 8.1.0 release of click breaks black; so we pin.
+  click==8.0.1
   isort==5.8.0
 commands =
   black .

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
   {[_integration]deps}
 commands =
   {[_integration]commands}
+  pex --version
   pex -r {toxinidir}/examples/event_based/requirements.txt -o {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambdex build -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
@@ -36,6 +37,7 @@ deps =
   .[test-gcp-http]
 commands =
   {[_integration]commands}
+  pex --version
   pex -r {toxinidir}/examples/gcp_http/requirements.txt -o {toxinidir}/dist/gcp_http_function.pex
   {toxinidir}/dist/lambdex build -s examples/gcp_http/example_http_function.py -H handler -M main.py {toxinidir}/dist/gcp_http_function.pex
   {toxinidir}/dist/lambdex test --type gcp-http --empty {toxinidir}/dist/gcp_http_function.pex
@@ -65,7 +67,8 @@ commands =
 
 [testenv:pex]
 deps = pex==2.1.43
-commands = pex . -c lambdex -o {toxinidir}/dist/lambdex
+commands =
+  python scripts/build-lambdex-pex.py {toxinidir}/dist/lambdex
 
 [testenv:lambdex]
 commands = lambdex {posargs}


### PR DESCRIPTION
Several deps had drifted into territory that led to errors with Python
2.7 and 3.6 shards; those are now constrained appropriately.

In addition, Pex 2.1.110 brought further hardening to the PEX boot 
`sys.path` scrubbing process which revealed a latent bug in the way the
Lambdex PEX used in tests was being constructed. That is now fixed with
a dedicated script to create that Lambdex PEX and ensure it's built with
the intended version of Pex.