### PR TITLE
Migrate from macos-10.15 to macos-11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
     strategy:
       matrix:
         python-version: [[2, 7], [3, 6], [3, 7], [3, 8], [3, 9]]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 6]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 7]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 8]
     steps:
       - name: Checkout Lambdex


### PR DESCRIPTION
This gets ahead of the deprecation tracked here:
https://github.com/actions/runner-images/issues/5583