### PR TITLE
Prepare the 0.1.7 release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
       matrix:
         include:
           - check-name: Format
-            python-version: 3.9
+            python-version: "3.10"
             tox-env: fmt-check
           - check-name: Packaging
-            python-version: 3.9
+            python-version: "3.10"
             tox-env: package
     steps:
       - name: Checkout Lambdex
@@ -25,19 +25,38 @@ jobs:
         with:
           tox-env: ${{ matrix.tox-env }}
   integration-tests:
-    name: (${{ matrix.os }}) TOXENV=py${{ join(matrix.python-version, '') }}-int-pre-pex1.6,py${{ join(matrix.python-version, '') }}-int-post-pex1.6
+    name: (${{ matrix.os }}) TOXENV=py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-int-${{ matrix.it-selector }}-pex1.6
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [[2, 7], [3, 6], [3, 7], [3, 8], [3, 9]]
-        os: [ubuntu-20.04, macos-11]
-        exclude:
-          - os: macos-11
-            python-version: [3, 6]
-          - os: macos-11
-            python-version: [3, 7]
-          - os: macos-11
-            python-version: [3, 8]
+        include:
+          - python-version: [2, 7]
+            os: macos-11
+            it-selector: "{pre,post}"
+          - python-version: [2, 7]
+            os: ubuntu-20.04
+            it-selector: "{pre,post}"
+          - python-version: [3, 6]
+            os: ubuntu-20.04
+            it-selector: "{pre,post}"
+          - python-version: [3, 7]
+            os: ubuntu-20.04
+            it-selector: "{pre,post}"
+          - python-version: [3, 8]
+            os: ubuntu-20.04
+            it-selector: "{pre,post}"
+          - python-version: [3, 9]
+            os: ubuntu-20.04
+            it-selector: "{pre,post}"
+          - python-version: [3, 10]
+            os: macos-11
+            it-selector: "post"
+          - python-version: [3, 10]
+            os: ubuntu-20.04
+            it-selector: "post"
+          - python-version: [3, 11, "0-rc.2"]
+            os: ubuntu-20.04
+            it-selector: "post"
     steps:
       - name: Checkout Lambdex
         uses: actions/checkout@v3
@@ -48,4 +67,4 @@ jobs:
       - name: Run Integration Tests
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
-          tox-env: py${{ join(matrix.python-version, '') }}-int-pre-pex1.6,py${{ join(matrix.python-version, '') }}-int-post-pex1.6
+          tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-int-${{ matrix.it-selector }}-pex1.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.1.7
+
+This release brings official support for Python 3.10 and 3.11.
+
 ## 0.1.6
 
 This release brings support for creating a lambdex that works on GCP. The feature should work for

--- a/lambdex/version.py
+++ b/lambdex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,15 @@ classifiers = [
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Topic :: Software Development :: Build Tools",
   "Topic :: System :: Archiving :: Packaging",
   "Topic :: System :: Software Distribution",
   "Topic :: Utilities",
 ]
 requires = ["pex>=1.1.15"]
-requires-python = ">=2.7,<3.10,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+requires-python = ">=2.7,<3.12,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [tool.flit.metadata.requires-extra]
 test-gcp-http = [

--- a/tox.ini
+++ b/tox.ini
@@ -43,14 +43,15 @@ commands =
   {toxinidir}/dist/lambdex test --type gcp-http --empty {toxinidir}/dist/gcp_http_function.pex
 
 [testenv:py{27,36,37,38,39}-int-pre-pex1.6]
-# NB: 1.4.8 is the first pre-1.6.0 version to support -c.
+# NB: 1.4.8 is the first pre-1.6.0 version to support -c and Python 3.9 is the last version to
+# support collections.Iterable which 1.4.8 uses.
 deps =
   {[_event_integration]deps}
   pex==1.4.8
 commands =
   {[_event_integration]commands}
 
-[testenv:py{27,36,37,38,39}-int-post-pex1.6]
+[testenv:py{27,36,37,38,39,310,311}-int-post-pex1.6]
 deps =
   {[_event_integration]deps}
   {[_gcp_http_integration]deps}
@@ -66,7 +67,10 @@ commands =
   {toxinidir}/dist/lambdex test --empty {toxinidir}/dist/lambda_function.pex
 
 [testenv:pex]
-deps = pex==2.1.43
+deps =
+  pex==2.1.43; python_version < "3.10"
+  # N.B.: This is the lowest version of Pex to support up through Python 3.11.
+  pex==2.1.89; python_version >= "3.10"
 commands =
   python scripts/build-lambdex-pex.py {toxinidir}/dist/lambdex
 


### PR DESCRIPTION
This brings official support for Python 3.10 and 3.11.