### PR TITLE
An option to write the result to a new file.

### DIFF
--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -60,7 +60,6 @@ def write_lambdex_handler(pex_zip, options):
     if options.output:
         output_zip = options.output
         shutil.copy(pex_zip, output_zip, follow_symlinks=False)
-        output_zip = options.script
     else:
         output_zip = pex_zip
 

--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -59,7 +59,7 @@ def write_lambdex_handler(pex_zip, options):
 
     if options.output:
         output_zip = options.output
-        shutil.copyfile(pex_zip, output_zip, follow_symlinks=False)
+        shutil.copy(pex_zip, output_zip, follow_symlinks=False)
         output_zip = options.script
     else:
         output_zip = pex_zip

--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -59,7 +59,7 @@ def write_lambdex_handler(pex_zip, options):
 
     if options.output:
         output_zip = options.output
-        shutil.copy(pex_zip, output_zip, follow_symlinks=False)
+        shutil.copy(pex_zip, output_zip)
     else:
         output_zip = pex_zip
 

--- a/lambdex/bin/lambdex.py
+++ b/lambdex/bin/lambdex.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import pkgutil
+import shutil
 import sys
 import zipfile
 
@@ -56,6 +57,13 @@ def write_lambdex_handler(pex_zip, options):
     ):
         die("Must specify one of -s/--script or -e/--entry-point but not both.")
 
+    if options.output:
+        output_zip = options.output
+        shutil.copyfile(pex_zip, output_zip, follow_symlinks=False)
+        output_zip = options.script
+    else:
+        output_zip = pex_zip
+
     script = None
     if options.script is not None:
         method = options.handler
@@ -71,7 +79,7 @@ def write_lambdex_handler(pex_zip, options):
 
     lambdex_info = LambdexInfo(entry_point)
 
-    with contextlib.closing(zipfile.ZipFile(pex_zip, "a")) as zf:
+    with contextlib.closing(zipfile.ZipFile(output_zip, "a")) as zf:
         if script is not None:
             with open(os.path.realpath(options.script), "rb") as fp:
                 _write_zip_content(zf, script, fp.read())
@@ -86,6 +94,7 @@ def write_lambdex_handler(pex_zip, options):
 #   [-M module.py]
 #   [-s script.py]
 #   [-e pkg:symbol]
+#   [-o output_file.zip]
 def build_lambdex(args):
     write_lambdex_handler(args.pex, args)
 
@@ -136,6 +145,15 @@ def configure_build_command(parser):
         default="lambdex_handler.py",
         metavar="FILENAME",
         help="Root module of the lambda.",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        default=None,
+        metavar="FILENAME",
+        help="Write output to this path. Otherwise, modifies the input file in-place.",
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ commands =
   {[_integration]commands}
   pex --version
   pex -r {toxinidir}/examples/event_based/requirements.txt -o {toxinidir}/dist/lambda_function.pex
+  {toxinidir}/dist/lambdex build -o {toxinidir}/dist/lambda_function_copy.pex -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
+  {toxinidir}/dist/lambda_function_copy.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
   {toxinidir}/dist/lambdex build -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
   tox -e entry-point-env-var

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,6 @@ commands =
   {toxinidir}/dist/lambdex build -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
   tox -e entry-point-env-var
-allowlist_externals =
-  lambdex
-  lambda_function.pex
 
 [_gcp_http_integration]
 deps =
@@ -70,6 +67,9 @@ setenv =
   LAMBDEX_ENTRY_POINT = example_function:other_handler
 commands =
   {toxinidir}/dist/lambdex test --empty {toxinidir}/dist/lambda_function.pex
+allowlist_externals =
+  {toxinidir}/dist/lambdex
+  {toxinidir}/dist/lambda_function.pex
 
 [testenv:pex]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,9 @@ commands =
   {toxinidir}/dist/lambdex build -s examples/event_based/example_function.py -H handler -M lambdex_handler.py {toxinidir}/dist/lambda_function.pex
   {toxinidir}/dist/lambda_function.pex -c 'from lambdex_handler import handler; handler(\{"url":"https://github.com/pantsbuild/lambdex"\}, None)'
   tox -e entry-point-env-var
+allowlist_externals =
+  lambdex
+  lambda_function.pex
 
 [_gcp_http_integration]
 deps =


### PR DESCRIPTION
Useful in hermetic execution sandboxes in which input files can't be modified by tools in the sandbox.

This issue has been seen in the wild in an implementation of the REAPI, which writes the input files as read-only,
and which appears to be correct behavior per the spec (e.g., if the sandbox inputs were assembled by linking
to files in a loose-file CAS implementation).