### PR TITLE
support python 3.12

### DIFF
--- a/lambdex/resources/lambdex_handler.py
+++ b/lambdex/resources/lambdex_handler.py
@@ -25,10 +25,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(__entry_point__, ".bootstrap")))
 try:
     # PEX >= 1.6.0
     from pex.pex_bootstrapper import bootstrap_pex_env
-    from pex.third_party.pkg_resources import EntryPoint as __EntryPoint
 except ImportError:
     # PEX < 1.6.0 has an install requirement of setuptools which we leverage knowledge of.
     from _pex.pex_bootstrapper import bootstrap_pex_env
+
+try:
+    from pex.third_party.pkg_resources import EntryPoint as __EntryPoint
+except ImportError:
     from pkg_resources import EntryPoint as __EntryPoint
 
 bootstrap_pex_env(__entry_point__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Build Tools",
   "Topic :: System :: Archiving :: Packaging",
   "Topic :: System :: Software Distribution",
   "Topic :: Utilities",
 ]
 requires = ["pex>=1.1.15"]
-requires-python = ">=2.7,<3.12,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+requires-python = ">=2.7,<3.13,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [tool.flit.metadata.requires-extra]
 test-gcp-http = [


### PR DESCRIPTION
Using python3.12 if I run `pip install lambdex` I currently get an outdated version (0.1.3) (latest is 0.1.9)

```
λ ~/code/test/ .venv/bin/pip install lambdex  
Collecting lambdex
  Using cached lambdex-0.1.3-py2.py3-none-any.whl.metadata (294 bytes)
Collecting pex>=1.1.15 (from lambdex)
  Using cached pex-2.3.1-py2.py3-none-any.whl.metadata (7.4 kB)
Using cached lambdex-0.1.3-py2.py3-none-any.whl (5.2 kB)
Using cached pex-2.3.1-py2.py3-none-any.whl (3.4 MB)
Installing collected packages: pex, lambdex
Successfully installed lambdex-0.1.3 pex-2.3.1
```

Nor is the project currently locally installable with 3.12 

```
λ ~/code/lambdex/ main .venv/bin/pip install .
Processing /home/jackevans/code/lambdex
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pex>=1.1.15 (from lambdex==0.1.9)
  Using cached pex-2.3.1-py2.py3-none-any.whl.metadata (7.4 kB)
INFO: pip is looking at multiple versions of lambdex to determine which version is compatible with other requirements. This could take a while.
ERROR: Package 'lambdex' requires a different Python: 3.12.2 not in '!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<3.12,>=2.7'
```
